### PR TITLE
fix: dynamically determine path to heroku executable

### DIFF
--- a/heroku.sh
+++ b/heroku.sh
@@ -5,8 +5,10 @@ set -Eeuo pipefail
 query="$1"
 cache_file=".appscache"
 
+heroku_path="$(which heroku)"
+
 update_apps_list() {
-  /usr/local/bin/heroku apps --all | \
+  $heroku_path apps --all | \
     grep -v '===' | \
     awk '{print $1}' | \
     awk NF > $cache_file


### PR DESCRIPTION
Hi there! Not sure if this repository is still maintained, but I've been successfully using this workflow for years, even on Alfred 5! Thanks for building this 🙂


I noticed when setting up a new machine that Heroku now recommends installing their CLI via homebrew on macOS: https://devcenter.heroku.com/articles/heroku-cli

As a result, the path to the Heroku executable is `/opt/homebrew/bin/heroku` for me. This PR updates the shell script to grab the path to the executable using `which heroku`. I made this change manually in my workflow file and confirmed it fixes this workflow.
